### PR TITLE
Bugfixes :)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ if rpm -q NetworkManager; then
   service network start
 fi
 if ! ls packstack-answers*; then
+  yum install -y e2fsprogs
   yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm
   yum update -y
   yum install -y openstack-packstack

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,7 @@ if ! ls packstack-answers*; then
             --os-neutron-ml2-type-drivers=vxlan,flat \
             --os-heat-install=y \
             --os-ceilometer-install=n \
-            --os-aodh-install=n \
-            --os-gnocchi-install=n
+            --os-aodh-install=n
 fi
 
 source ~/keystonerc_admin

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@
 $script = <<SCRIPT
 if rpm -q NetworkManager; then
   service NetworkManager stop
+  kill $(pgrep dhclient)
   yum remove -y NetworkManager
   chkconfig network on
   service network start


### PR DESCRIPTION
Minor bugfixes :)

[7fefee9]
    default: Usage: packstack [options] [--help]
    default: 
    default: packstack: error: no such option: --os-gnocchi-install

[d72147c]
   default: ERROR : Error appeared during Puppet run: 192.168.33.30_controller.pp
    default: Error: /Stage[main]/Packstack::Swift::Storage/Swift::Storage::Loopback[swiftloopback]/Swift::Storage::Ext4[swiftloopback]/Exec[mkfs-swiftloopback]: Failed to call refresh: Could not find command 'mkfs.ext4'

[7fefee9]
    default: Dependency Removed:
    default:   NetworkManager-team.x86_64 1:1.10.2-16.el7_5                                  
    default:   NetworkManager-tui.x86_64 1:1.10.2-16.el7_5                                   
    default: Complete!
    default: Starting network (via systemctl):  
    default: Job for network.service failed because the control process exited with error code. See "systemctl status network.service" and "journalctl -xe" for details.
    default: [FAILED]

Cheers!
-M