### PR TITLE
Work-around no longer supported --os-gnocchi-install option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,7 @@ if ! ls packstack-answers*; then
             --os-neutron-ml2-type-drivers=vxlan,flat \
             --os-heat-install=y \
             --os-ceilometer-install=n \
-            --os-aodh-install=n \
-            --os-gnocchi-install=n
+            --os-aodh-install=n
 fi
 
 source ~/keystonerc_admin


### PR DESCRIPTION
Supposedly fixes https://github.com/hogepodge/getting-started-with-openstack/issues/4 as installation seems to work, then.

Dunno if there are side effects, though.